### PR TITLE
Remove deprecated modmenu stuff

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -28,10 +28,5 @@
   },
   "suggests": {
     "flamingo": "*"
-  },
-  "custom": {
-    "modmenu:api": false,
-    "modmenu:clientsideOnly": true,
-    "modmenu:parent": ""
   }
 }


### PR DESCRIPTION
- ModMenu parent has been changed in the new api, and it is useless here anyway
- ModMenu api tag has been removed
- ModMenu clientsideonly is now autodetected and has therefore been removed